### PR TITLE
Build portable Linux binaries with musl static linking

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -86,20 +86,21 @@
             };
           };
 
-          # Cross-compilation packages
-          x86_64-linux = pkgs.stdenv.mkDerivation {
+          # Cross-compilation packages (statically linked with musl for portability)
+          x86_64-linux = pkgs.pkgsStatic.stdenv.mkDerivation {
             pname = "try";
             version = builtins.replaceStrings ["\n"] [""] (builtins.readFile ./VERSION);
 
             src = inputs.self;
 
-            nativeBuildInputs = with pkgs; [
+            nativeBuildInputs = with pkgs.pkgsStatic; [
               gcc
               gnumake
             ];
 
+            # Force static linking for portable binary
             buildPhase = ''
-              make
+              make LDFLAGS="-static"
             '';
 
             installPhase = ''
@@ -116,19 +117,20 @@
             };
           };
 
-          aarch64-linux = pkgs.pkgsCross.aarch64-multiplatform.stdenv.mkDerivation {
+          aarch64-linux = pkgs.pkgsCross.aarch64-multiplatform-musl.stdenv.mkDerivation {
             pname = "try";
             version = builtins.replaceStrings ["\n"] [""] (builtins.readFile ./VERSION);
 
             src = inputs.self;
 
-            nativeBuildInputs = with pkgs.pkgsCross.aarch64-multiplatform; [
+            nativeBuildInputs = with pkgs.pkgsCross.aarch64-multiplatform-musl; [
               gcc
               gnumake
             ];
 
+            # Force static linking for portable binary
             buildPhase = ''
-              make
+              make LDFLAGS="-static"
             '';
 
             installPhase = ''


### PR DESCRIPTION
## Summary

- Switch Linux release builds from glibc (dynamic) to musl (static)
- Binaries are now fully self-contained with no runtime dependencies

## Problem

The release binaries were dynamically linked against Nix's glibc 2.40, making them non-portable to systems with older glibc versions:

```
/lib/x86_64-linux-gnu/libc.so.6: version 'GLIBC_2.38' not found
```

This contradicts the README's claim of "zero dependencies" and "single statically-linked binary".

## Solution

- Use `pkgs.pkgsStatic` for x86_64-linux (musl-based static toolchain)
- Use `pkgs.pkgsCross.aarch64-multiplatform-musl` for aarch64-linux
- Pass `LDFLAGS="-static"` to ensure fully static binaries

## Binary size comparison

| Build | Size |
|-------|------|
| Dynamic (current) | 94 KB |
| Static (this PR) | 182 KB |

The ~2x size increase is a reasonable tradeoff for true portability.

## Test plan

Verified locally with Nix:

```bash
$ nix build .#packages.x86_64-linux.x86_64-linux
$ file ./result/bin/try
./result/bin/try: ELF 64-bit LSB executable, x86-64, version 1 (SYSV), statically linked, not stripped

$ nix build .#packages.x86_64-linux.aarch64-linux
$ file ./result/bin/try
./result/bin/try: ELF 64-bit LSB executable, ARM aarch64, version 1 (SYSV), statically linked, not stripped
```