### PR TITLE
Add macOS release builds using native runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,21 +61,21 @@ jobs:
     environment: OpenSource
     name: Build macOS (${{ matrix.arch }})
     if: startsWith(github.ref, 'refs/tags/')
-    runs-on: ${{ matrix.runner }}
+    runs-on: macos-latest
     strategy:
       matrix:
         include:
-          - runner: macos-13
-            arch: x86_64
-          - runner: macos-latest
-            arch: aarch64
+          - arch: x86_64
+            cc: clang -arch x86_64
+          - arch: aarch64
+            cc: clang
 
     steps:
     - name: Checkout code
       uses: actions/checkout@v5
 
     - name: Build
-      run: make
+      run: make CC="${{ matrix.cc }}"
 
     - name: Upload build artifact
       uses: actions/upload-artifact@v5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,11 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        target: [x86_64-linux, aarch64-linux]
+        include:
+          - target: x86_64-linux
+            artifact: try-linux-x86_64
+          - target: aarch64-linux
+            artifact: try-linux-aarch64
 
     steps:
     - name: Checkout code
@@ -49,7 +53,7 @@ jobs:
     - name: Upload build artifact
       uses: actions/upload-artifact@v5
       with:
-        name: try-${{ matrix.target }}
+        name: ${{ matrix.artifact }}
         path: result/bin/try
         retention-days: 7
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,11 +34,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        include:
-          - target: x86_64-linux
-            artifact: try-linux-x86_64
-          - target: aarch64-linux
-            artifact: try-linux-aarch64
+        target: [x86_64-linux, aarch64-linux]
 
     steps:
     - name: Checkout code
@@ -53,7 +49,7 @@ jobs:
     - name: Upload build artifact
       uses: actions/upload-artifact@v5
       with:
-        name: ${{ matrix.artifact }}
+        name: try-${{ matrix.target }}
         path: result/bin/try
         retention-days: 7
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,11 +53,38 @@ jobs:
         path: result/bin/try
         retention-days: 7
 
+  build-macos:
+    environment: OpenSource
+    name: Build macOS (${{ matrix.arch }})
+    if: startsWith(github.ref, 'refs/tags/')
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      matrix:
+        include:
+          - runner: macos-13
+            arch: x86_64
+          - runner: macos-latest
+            arch: aarch64
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v5
+
+    - name: Build
+      run: make
+
+    - name: Upload build artifact
+      uses: actions/upload-artifact@v5
+      with:
+        name: try-darwin-${{ matrix.arch }}
+        path: dist/try
+        retention-days: 7
+
   release:
     environment: OpenSource
     name: Create Release
     if: startsWith(github.ref, 'refs/tags/')
-    needs: cross-compile
+    needs: [cross-compile, build-macos]
     runs-on: ubuntu-latest
     permissions:
       contents: write


### PR DESCRIPTION
## Summary

Restores macOS release builds that were removed in 59da0b07.

### How the regression happened

The original `build.yml` (still visible at v1.4.1) built macOS binaries natively on macOS runners. When the workflows were consolidated into `ci.yml`, all builds were moved to a single `ubuntu-latest` runner using Nix cross-compilation. Nix can't cross-compile Darwin targets from Linux runners, so when the Darwin builds failed in CI, they were removed entirely in 59da0b07 rather than being moved back to native macOS runners.

### What this PR does

Adds a `build-macos` job that builds Darwin binaries natively on `macos-latest`. The aarch64 build compiles natively; the x86_64 build cross-compiles via `clang -arch x86_64`.

### Verified

Triggered a test release on my fork — [CI run here](https://github.com/kaelig/try-cli/actions/runs/22253630461). All build and release jobs passed (the FlakeHub/AUR publish jobs failed as expected since they need upstream secrets):

| Job | Status |
|-----|--------|
| Cross-compile (x86_64-linux) | ✅ |
| Cross-compile (aarch64-linux) | ✅ |
| Build macOS (x86_64) | ✅ |
| Build macOS (aarch64) | ✅ |
| Create Release | ✅ |

Fixes #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)