### PR TITLE
Add multi-environment mode and one-command setup feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,12 +41,26 @@ sudo mv try /usr/local/bin/
 
 ### Shell integration
 
-```bash
-# Add to your shell (bash/zsh)
-echo 'eval "$(try init ~/src/tries)"' >> ~/.zshrc
+**One-command setup** (auto-detects your shell and config file):
 
-# For fish shell users
-echo 'eval (try init ~/src/tries | string collect)' >> ~/.config/fish/config.fish
+```bash
+# Multi-env mode: creates ~/src with tries/, experiments/, prod/ subdirectories
+try init --base ~/src --install
+
+# Single-root mode: all experiments in one folder
+try init ~/src/tries --install
+```
+
+That's it. It creates the directories, detects your shell (zsh/bash/fish), and appends the shell function to the right config file. Restart your shell or `source` the file and you're ready.
+
+**Manual setup** (if you prefer `eval`):
+
+```bash
+# bash/zsh
+eval "$(try init --base ~/src)"
+
+# fish
+eval (try init --base ~/src | string collect)
 ```
 
 ### Build from source
@@ -99,27 +113,46 @@ Not just substring matching - it's smart:
 - Dark mode by default (because obviously)
 
 ### 📁 Organized Chaos
-- Everything lives in `~/src/tries` (configurable via `--path` or `TRY_PATH`)
+- Everything lives in `~/src/tries` (configurable via `--path`)
 - Auto-prefixes with dates: `2025-11-30-your-idea`
 - Skip the date prompt if you already typed a name
 
+### 🌍 Multi-Environment
+- Use `try init --base ~/src` to organize into multiple environments
+- Each subdirectory of `~/src` becomes an environment (tries, experiments, prod, etc.)
+- First pick an environment, then pick or create a project within it
+- Great for separating experiments from production workspaces
+
 ### Shell Integration
 
-- Bash/Zsh:
+- **Automatic** (recommended):
+
+  ```bash
+  try init --base ~/src --install    # multi-env
+  try init ~/src/tries --install     # single-root
+  ```
+
+  Auto-detects your shell and appends to `~/.zshrc`, `~/.bashrc`, or `~/.config/fish/config.fish`.
+
+- **Manual** (bash/zsh):
 
   ```bash
   # Default is ~/src/tries
   eval "$(try init)"
   # Or pick a path
   eval "$(try init ~/code/experiments)"
+  # Or use multi-env mode
+  eval "$(try init --base ~/src)"
   ```
 
-- Fish:
+- **Manual** (fish):
 
   ```fish
   eval (try init | string collect)
   # Or pick a path
   eval (try init ~/code/experiments | string collect)
+  # Or use multi-env mode
+  eval (try init --base ~/src | string collect)
   ```
 
 Notes:
@@ -134,6 +167,134 @@ try clone https://github.com/user/repo.git  # Clone repo into date-prefixed dire
 try https://github.com/user/repo.git        # Shorthand for clone (same as above)
 try --help                                   # See all options
 ```
+
+### Multi-Environment Mode
+
+With `try init --base ~/src`, you get a two-step picker:
+
+```
+$ try
+🌍 Select Environment
+──────────────────────────────
+→ 📁 experiments
+  📁 prod
+  📁 tries
+  📂 Create new: ...
+
+  ↑/↓: Navigate  Enter: Select  Type to create new  Esc: Cancel
+```
+
+Pick an environment, then the usual project picker appears for that environment.
+Create new environments by typing a name that doesn't match any existing one.
+
+#### Step-by-step walkthrough
+
+**1. Set up your base directory**
+
+Create a parent folder that will hold all your environment folders:
+
+```bash
+mkdir -p ~/src
+```
+
+**2. Install with one command**
+
+`--install` auto-detects your shell, creates the directories, and appends the shell function to your config:
+
+```bash
+try init --base ~/src --install
+```
+
+Output:
+```
+Installed to /home/user/.zshrc (zsh)
+Multi-env mode: /home/user/src (environments: tries, experiments, prod)
+Restart your shell or run: source /home/user/.zshrc
+```
+
+This creates `~/src` with three default environment folders (`tries`, `experiments`, `prod`) and adds the shell function to your `.zshrc`/`.bashrc`/fish config. No manual editing needed.
+
+**3. Restart your shell (or source the config)**
+
+```bash
+source ~/.zshrc   # or ~/.bashrc, or config.fish
+```
+
+**4. Use the two-step picker**
+
+```bash
+$ try
+```
+
+First, the **environment picker** appears showing all subdirectories of `~/src`:
+
+```
+🌍 Select Environment
+──────────────────────────────
+→ 📁 experiments
+  📁 prod
+  📁 tries
+  📂 Create new: ...
+
+  ↑/↓: Navigate  Enter: Select  Type to create new  Esc: Cancel
+```
+
+Select one (e.g. `tries`), then the **project picker** appears for that environment:
+
+```
+📁 ~/src/tries — Try Directory Selection
+──────────────────────────────
+→ 2026-04-19-redis-test         2h ago
+  2026-04-18-thread-pool        1d ago
+  2026-03-22-db-pooling         4w ago
+  + Create new: ...
+
+  ↑/↓: Navigate  Enter: Select  Type to filter/create  Ctrl-D: Delete  Ctrl-R: Rename  Esc: Cancel
+```
+
+**5. Create new environments on the fly**
+
+The three default environments (`tries`, `experiments`, `prod`) are created automatically by `--install`. You can add more on the fly:
+
+```
+🌍 Select Environment
+──────────────────────────────
+  📁 experiments
+  📁 prod
+  📁 tries
+→ 📂 Create new: prototypes
+
+  ↑/↓: Navigate  Enter: Select  Type to create new  Esc: Cancel
+```
+
+Press Enter and `~/src/prototypes` is created, then you land in the project picker for it.
+
+**6. Resulting directory structure**
+
+```
+~/src/
+├── tries/
+│   ├── 2026-04-19-redis-test/
+│   └── 2026-04-18-thread-pool/
+├── experiments/
+│   ├── 2026-04-17-rust-wasm/
+│   └── 2026-04-15-ml-model/
+├── prod/
+│   └── 2026-04-10-api-server/
+└── prototypes/          ← created on the fly
+    └── 2026-04-19-new-concept/
+```
+
+#### Comparison: Single-root vs Multi-env
+
+| | Single-root | Multi-env |
+|---|---|---|
+| **One-command setup** | `try init ~/src/tries --install` | `try init --base ~/src --install` |
+| **Manual setup** | `eval "$(try init ~/src/tries)"` | `eval "$(try init --base ~/src)"` |
+| **Picker steps** | 1 (projects only) | 2 (env then project) |
+| **Directory layout** | All projects flat in one folder | Projects grouped under env folders |
+| **Create new env** | N/A | Type a new name in the env picker |
+| **Delete/Rename** | Available for projects | Available for projects only (not envs) |
 
 ### Git Repository Cloning
 
@@ -171,19 +332,49 @@ The `.git` suffix is automatically removed from URLs when generating directory n
 
 ## Configuration
 
-Set `TRY_PATH` to change where experiments are stored:
+### Single-root mode
+
+All experiments in one folder:
 
 ```bash
-export TRY_PATH=~/code/sketches
-```
+# Automatic
+try init ~/code/sketches --install
 
-Or use the `--path` flag:
-
-```bash
+# Manual
 eval "$(try init ~/code/sketches)"
 ```
 
 Default: `~/src/tries`
+
+### Multi-env mode
+
+Separate environments under a base directory:
+
+```bash
+# Automatic (creates tries/, experiments/, prod/ subdirectories)
+try init --base ~/src --install
+
+# Manual
+eval "$(try init --base ~/src)"
+```
+
+This makes each subdirectory of `~/src` an environment (e.g. `~/src/tries`, `~/src/experiments`, `~/src/prod`). The TUI shows an environment picker first, then a project picker within the selected environment.
+
+### The `--install` flag
+
+Appends the shell function to your shell config file automatically:
+- Detects your shell from `$SHELL` (zsh, bash, or fish)
+- Appends to `~/.zshrc`, `~/.bashrc`, or `~/.config/fish/config.fish`
+- Skips if a `try` function is already present
+- Works with both single-root and multi-env modes
+
+### Override per-invocation
+
+Use `--path` to override the tries path for a single command:
+
+```bash
+try --path ~/code/sketches redis
+```
 
 ## Arch Linux
 

--- a/src/commands.c
+++ b/src/commands.c
@@ -336,13 +336,23 @@ static bool is_in_git_repo(void) {
 // Init command - outputs shell function definition
 // ============================================================================
 
-void cmd_init(int argc, char **argv, const char *tries_path) {
-  (void)argc; (void)argv; // May be used for future options
-
-  // If a positional argument is provided, use it as the tries path
-  // e.g., "try init /tmp/custom-path"
-  if (argc > 0 && argv[0] && argv[0][0] != '-') {
-    tries_path = argv[0];
+void cmd_init(int argc, char **argv, const char *tries_path, const char *base_path) {
+  // Parse init args: [path] [--base <path>] [--install]
+  // If --base is provided, use multi-env mode
+  // --install auto-appends to shell config file
+  bool install = false;
+  for (int i = 0; i < argc; i++) {
+    if (strcmp(argv[i], "--base") == 0 && i + 1 < argc) {
+      base_path = argv[i + 1];
+      i++; // skip value
+    } else if (strncmp(argv[i], "--base=", 7) == 0) {
+      base_path = argv[i] + 7;
+    } else if (strcmp(argv[i], "--install") == 0) {
+      install = true;
+    } else if (argv[i][0] != '-') {
+      // Positional arg = tries path (single-root mode)
+      tries_path = argv[i];
+    }
   }
 
   // Determine if we're in fish shell
@@ -385,29 +395,145 @@ void cmd_init(int argc, char **argv, const char *tries_path) {
 
   // Escape paths to prevent shell injection
   Z_CLEANUP(zstr_free) zstr escaped_self = shell_escape(self_path);
-  Z_CLEANUP(zstr_free) zstr escaped_tries = shell_escape(tries_path);
+
+  // In multi-env mode, create default environment subdirectories
+  if (base_path) {
+    const char *default_envs[] = {"tries", "experiments", "prod", NULL};
+    for (int i = 0; default_envs[i]; i++) {
+      Z_CLEANUP(zstr_free) zstr env_path = join_path(base_path, default_envs[i]);
+      if (!dir_exists(zstr_cstr(&env_path))) {
+        mkdir_p(zstr_cstr(&env_path));
+      }
+    }
+  }
+
+  // Build the shell function text into a buffer so we can both print and install
+  Z_CLEANUP(zstr_free) zstr func = zstr_init();
 
   if (is_fish) {
     // Fish shell version
-    printf(
-      "function try\n"
-      "  set -l out (%s exec --path %s $argv 2>/dev/tty)\n"
-      "  or begin; echo $out; return $status; end\n"
-      "  eval $out\n"
-      "end\n",
-      zstr_cstr(&escaped_self), zstr_cstr(&escaped_tries));
+    if (base_path) {
+      Z_CLEANUP(zstr_free) zstr escaped_base = shell_escape(base_path);
+      zstr_fmt(&func,
+        "function try\n"
+        "  set -l out (%s exec --base %s $argv 2>/dev/tty)\n"
+        "  or begin; echo $out; return $status; end\n"
+        "  eval $out\n"
+        "end\n",
+        zstr_cstr(&escaped_self), zstr_cstr(&escaped_base));
+    } else {
+      Z_CLEANUP(zstr_free) zstr escaped_tries = shell_escape(tries_path);
+      zstr_fmt(&func,
+        "function try\n"
+        "  set -l out (%s exec --path %s $argv 2>/dev/tty)\n"
+        "  or begin; echo $out; return $status; end\n"
+        "  eval $out\n"
+        "end\n",
+        zstr_cstr(&escaped_self), zstr_cstr(&escaped_tries));
+    }
   } else {
     // Bash/Zsh version
-    printf(
-      "try() {\n"
-      "  local out\n"
-      "  out=$(%s exec --path %s \"$@\" 2>/dev/tty) || {\n"
-      "    echo \"$out\"\n"
-      "    return $?\n"
-      "  }\n"
-      "  eval \"$out\"\n"
-      "}\n",
-      zstr_cstr(&escaped_self), zstr_cstr(&escaped_tries));
+    if (base_path) {
+      Z_CLEANUP(zstr_free) zstr escaped_base = shell_escape(base_path);
+      zstr_fmt(&func,
+        "try() {\n"
+        "  local out\n"
+        "  out=$(%s exec --base %s \"$@\" 2>/dev/tty) || {\n"
+        "    echo \"$out\"\n"
+        "    return $?\n"
+        "  }\n"
+        "  eval \"$out\"\n"
+        "}\n",
+        zstr_cstr(&escaped_self), zstr_cstr(&escaped_base));
+    } else {
+      Z_CLEANUP(zstr_free) zstr escaped_tries = shell_escape(tries_path);
+      zstr_fmt(&func,
+        "try() {\n"
+        "  local out\n"
+        "  out=$(%s exec --path %s \"$@\" 2>/dev/tty) || {\n"
+        "    echo \"$out\"\n"
+        "    return $?\n"
+        "  }\n"
+        "  eval \"$out\"\n"
+        "}\n",
+        zstr_cstr(&escaped_self), zstr_cstr(&escaped_tries));
+    }
+  }
+
+  if (install) {
+    // Auto-detect shell config file and append
+    Z_CLEANUP(zstr_free) zstr home = get_home_dir();
+    // Must persist rc_file zstr past the if/else so rc_path stays valid
+    Z_CLEANUP(zstr_free) zstr rc_file = zstr_init();
+    const char *shell_name = "sh";
+
+    if (is_fish) {
+      // Fish config
+      Z_CLEANUP(zstr_free) zstr fish_dir = join_path(zstr_cstr(&home), ".config/fish");
+      mkdir_p(zstr_cstr(&fish_dir));
+      rc_file = join_path(zstr_cstr(&fish_dir), "config.fish");
+      shell_name = "fish";
+    } else {
+      // Check for .zshrc first, then .bashrc
+      Z_CLEANUP(zstr_free) zstr zshrc = join_path(zstr_cstr(&home), ".zshrc");
+      Z_CLEANUP(zstr_free) zstr bashrc = join_path(zstr_cstr(&home), ".bashrc");
+
+      // Prefer based on $SHELL, fallback to whichever exists
+      if (shell && strstr(shell, "zsh")) {
+        rc_file = zstr_dup(&zshrc);
+        shell_name = "zsh";
+      } else if (shell && strstr(shell, "bash")) {
+        rc_file = zstr_dup(&bashrc);
+        shell_name = "bash";
+      } else if (file_exists(zstr_cstr(&zshrc))) {
+        rc_file = zstr_dup(&zshrc);
+        shell_name = "zsh";
+      } else {
+        rc_file = zstr_dup(&bashrc);
+        shell_name = "bash";
+      }
+    }
+
+    const char *rc_path = zstr_cstr(&rc_file);
+
+    // Check if already installed (look for "try()" or "function try")
+    bool already_installed = false;
+    FILE *f = fopen(rc_path, "r");
+    if (f) {
+      char line[1024];
+      while (fgets(line, sizeof(line), f)) {
+        if (strstr(line, "try() {") || strstr(line, "function try")) {
+          already_installed = true;
+          break;
+        }
+      }
+      fclose(f);
+    }
+
+    if (already_installed) {
+      fprintf(stderr, "Already installed in %s. To reinstall, remove the old 'try' function first.\n", rc_path);
+    } else {
+      // Append to rc file
+      f = fopen(rc_path, "a");
+      if (!f) {
+        fprintf(stderr, "Error: Could not write to %s\n", rc_path);
+      } else {
+        fprintf(f, "\n# try - ephemeral workspace manager\n");
+        fprintf(f, "%s", zstr_cstr(&func));
+        fclose(f);
+
+        fprintf(stderr, "Installed to %s (%s)\n", rc_path, shell_name);
+        if (base_path) {
+          fprintf(stderr, "Multi-env mode: %s (environments: tries, experiments, prod)\n", base_path);
+        } else {
+          fprintf(stderr, "Single-root mode: %s\n", tries_path);
+        }
+        fprintf(stderr, "Restart your shell or run: source %s\n", rc_path);
+      }
+    }
+  } else {
+    // Default: print to stdout for eval
+    printf("%s", zstr_cstr(&func));
   }
 
   if (resolved_path) {
@@ -419,7 +545,7 @@ void cmd_init(int argc, char **argv, const char *tries_path) {
 // Clone command - returns script
 // ============================================================================
 
-zstr cmd_clone(int argc, char **argv, const char *tries_path) {
+zstr cmd_clone(int argc, char **argv, const char *tries_path, const char *base_path) {
   if (argc < 1) {
     fprintf(stderr, "Usage: try clone <url> [name]\n");
     return zstr_init(); // Empty = error
@@ -428,8 +554,13 @@ zstr cmd_clone(int argc, char **argv, const char *tries_path) {
   const char *url = argv[0];
   const char *name = (argc > 1) ? argv[1] : NULL;
 
+  // In multi-env mode, clone into the first environment's directory
+  // (clone doesn't show env picker - user can specify via --path)
+  const char *target_path = tries_path;
+  (void)base_path;
+
   Z_CLEANUP(zstr_free) zstr dir_name = make_clone_dirname(url, name);
-  Z_CLEANUP(zstr_free) zstr full_path = join_path(tries_path, zstr_cstr(&dir_name));
+  Z_CLEANUP(zstr_free) zstr full_path = join_path(target_path, zstr_cstr(&dir_name));
 
   return build_clone_script(url, zstr_cstr(&full_path));
 }
@@ -438,13 +569,17 @@ zstr cmd_clone(int argc, char **argv, const char *tries_path) {
 // Worktree command - returns script
 // ============================================================================
 
-zstr cmd_worktree(int argc, char **argv, const char *tries_path) {
+zstr cmd_worktree(int argc, char **argv, const char *tries_path, const char *base_path) {
   if (argc < 1) {
     fprintf(stderr, "Usage: try worktree <name>\n");
     return zstr_init(); // Empty = error
   }
 
   const char *name = argv[0];
+
+  // In multi-env mode, worktree goes into the first environment's directory
+  const char *target_path = tries_path;
+  (void)base_path;
 
   // Build date-prefixed path
   time_t now = time(NULL);
@@ -456,7 +591,7 @@ zstr cmd_worktree(int argc, char **argv, const char *tries_path) {
   zstr_cat(&dir_name, "-");
   zstr_cat(&dir_name, name);
 
-  Z_CLEANUP(zstr_free) zstr full_path = join_path(tries_path, zstr_cstr(&dir_name));
+  Z_CLEANUP(zstr_free) zstr full_path = join_path(target_path, zstr_cstr(&dir_name));
 
   // Check if we're in a git repo
   if (is_in_git_repo()) {
@@ -471,10 +606,65 @@ zstr cmd_worktree(int argc, char **argv, const char *tries_path) {
 // Selector command - returns script
 // ============================================================================
 
-zstr cmd_selector(int argc, char **argv, const char *tries_path, TestParams *test) {
+zstr cmd_selector(int argc, char **argv, const char *tries_path, TestParams *test, const char *base_path) {
   const char *initial_filter = (argc > 0) ? argv[0] : NULL;
 
-  SelectionResult result = run_selector(tries_path, initial_filter, test);
+  // Multi-env mode: show env picker first, then folder picker
+  if (base_path) {
+    // Step 1: Environment picker
+    SelectionResult env_result = run_selector(base_path, NULL, test, SELECTOR_ENVS);
+
+    if (env_result.type == ACTION_CANCEL) {
+      fprintf(stderr, "Cancelled.\n");
+      zstr_free(&env_result.path);
+      return zstr_init();
+    }
+
+    // The selected env becomes the tries_path for the folder picker
+    const char *env_path;
+    Z_CLEANUP(zstr_free) zstr owned_path = zstr_init();
+
+    if (env_result.type == ACTION_MKDIR) {
+      // New env was created - use its path
+      env_path = zstr_cstr(&env_result.path);
+    } else {
+      // Existing env selected (ACTION_CD) - use its path
+      env_path = zstr_cstr(&env_result.path);
+    }
+
+    // Step 2: Folder picker within selected environment
+    SelectionResult result = run_selector(env_path, initial_filter, test, SELECTOR_FOLDERS);
+
+    zstr script = zstr_init();
+
+    if (result.type == ACTION_CD) {
+      script = build_cd_script(zstr_cstr(&result.path));
+    } else if (result.type == ACTION_MKDIR) {
+      script = build_mkdir_script(zstr_cstr(&result.path));
+    } else if (result.type == ACTION_DELETE) {
+      script = build_delete_script(env_path, &result.delete_names);
+      zstr *iter;
+      vec_foreach(&result.delete_names, iter) {
+        zstr_free(iter);
+      }
+      vec_free_zstr(&result.delete_names);
+    } else if (result.type == ACTION_RENAME) {
+      script = build_rename_script(env_path,
+                                    zstr_cstr(&result.rename_old_name),
+                                    zstr_cstr(&result.rename_new_name));
+      zstr_free(&result.rename_old_name);
+      zstr_free(&result.rename_new_name);
+    } else {
+      fprintf(stderr, "Cancelled.\n");
+    }
+
+    zstr_free(&env_result.path);
+    zstr_free(&result.path);
+    return script;
+  }
+
+  // Single-root mode (original behavior)
+  SelectionResult result = run_selector(tries_path, initial_filter, test, SELECTOR_FOLDERS);
 
   zstr script = zstr_init();
 
@@ -509,10 +699,10 @@ zstr cmd_selector(int argc, char **argv, const char *tries_path, TestParams *tes
 // Route subcommands (for exec mode or main routing)
 // ============================================================================
 
-zstr cmd_route(int argc, char **argv, const char *tries_path, TestParams *test) {
+zstr cmd_route(int argc, char **argv, const char *tries_path, TestParams *test, const char *base_path) {
   // No subcommand = interactive selector
   if (argc == 0) {
-    return cmd_selector(0, NULL, tries_path, test);
+    return cmd_selector(0, NULL, tries_path, test, base_path);
   }
 
   const char *subcmd = argv[0];
@@ -530,31 +720,31 @@ zstr cmd_route(int argc, char **argv, const char *tries_path, TestParams *test) 
     extern bool tui_no_colors;
     tui_no_colors = true;
     // Continue with remaining args
-    return cmd_route(argc - 1, argv + 1, tries_path, test);
+    return cmd_route(argc - 1, argv + 1, tries_path, test, base_path);
   }
 
   if (strcmp(subcmd, "init") == 0) {
     // Init always prints directly
-    cmd_init(argc - 1, argv + 1, tries_path);
+    cmd_init(argc - 1, argv + 1, tries_path, base_path);
     return zstr_init();
   } else if (strcmp(subcmd, "cd") == 0) {
     // Check if argument is a URL (clone shorthand)
     if (argc > 1 && (strncmp(argv[1], "https://", 8) == 0 ||
                      strncmp(argv[1], "http://", 7) == 0 ||
                      strncmp(argv[1], "git@", 4) == 0)) {
-      return cmd_clone(argc - 1, argv + 1, tries_path);
+      return cmd_clone(argc - 1, argv + 1, tries_path, base_path);
     }
     // Explicit cd command
-    return cmd_selector(argc - 1, argv + 1, tries_path, test);
+    return cmd_selector(argc - 1, argv + 1, tries_path, test, base_path);
   } else if (strcmp(subcmd, "clone") == 0) {
-    return cmd_clone(argc - 1, argv + 1, tries_path);
+    return cmd_clone(argc - 1, argv + 1, tries_path, base_path);
   } else if (strcmp(subcmd, "worktree") == 0) {
-    return cmd_worktree(argc - 1, argv + 1, tries_path);
+    return cmd_worktree(argc - 1, argv + 1, tries_path, base_path);
   } else if (strncmp(subcmd, "https://", 8) == 0 ||
              strncmp(subcmd, "http://", 7) == 0 ||
              strncmp(subcmd, "git@", 4) == 0) {
     // URL shorthand for clone
-    return cmd_clone(argc, argv, tries_path);
+    return cmd_clone(argc, argv, tries_path, base_path);
   } else if (strcmp(subcmd, ".") == 0) {
     // Dot shorthand for worktree (requires name)
     if (argc < 2) {
@@ -562,9 +752,9 @@ zstr cmd_route(int argc, char **argv, const char *tries_path, TestParams *test) 
       fprintf(stderr, "The name argument is required for worktree creation.\n");
       return zstr_init();
     }
-    return cmd_worktree(argc - 1, argv + 1, tries_path);
+    return cmd_worktree(argc - 1, argv + 1, tries_path, base_path);
   } else {
     // Treat as query for selector (cd is default)
-    return cmd_selector(argc, argv, tries_path, test);
+    return cmd_selector(argc, argv, tries_path, test, base_path);
   }
 }

--- a/src/commands.h
+++ b/src/commands.h
@@ -7,16 +7,19 @@
 #define SCRIPT_HEADER "# if you can read this, you didn't launch try from an alias. run try --help.\n"
 
 // Init command - outputs shell function definition (always prints directly)
-void cmd_init(int argc, char **argv, const char *tries_path);
+// tries_path: single-root mode (NULL in multi-env mode)
+// base_path: multi-env base directory (NULL in single-root mode)
+void cmd_init(int argc, char **argv, const char *tries_path, const char *base_path);
 
 // Commands return shell scripts to execute
 // Returns empty zstr on error (after printing error to stderr)
-zstr cmd_clone(int argc, char **argv, const char *tries_path);
-zstr cmd_worktree(int argc, char **argv, const char *tries_path);
-zstr cmd_selector(int argc, char **argv, const char *tries_path, TestParams *test);
+// base_path: if non-NULL, enables multi-env mode (env picker first)
+zstr cmd_clone(int argc, char **argv, const char *tries_path, const char *base_path);
+zstr cmd_worktree(int argc, char **argv, const char *tries_path, const char *base_path);
+zstr cmd_selector(int argc, char **argv, const char *tries_path, TestParams *test, const char *base_path);
 
 // Route subcommands (for exec mode)
-zstr cmd_route(int argc, char **argv, const char *tries_path, TestParams *test);
+zstr cmd_route(int argc, char **argv, const char *tries_path, TestParams *test, const char *base_path);
 
 // Execute or print a script
 // exec_mode: true = print with header, false = execute via bash

--- a/src/main.c
+++ b/src/main.c
@@ -33,12 +33,12 @@ static void print_help(void) {
   zstr_cat(&help, "  ");
   tui_zstr_printf(&help, ANSI_BRIGHT_BLUE, "# bash/zsh (~/.bashrc or ~/.zshrc)");
   zstr_cat(&help, "\n");
-  zstr_cat(&help, "  eval \"$(try init ~/src/tries)\"\n\n");
+  zstr_cat(&help, "  try init --base ~/src --install\n\n");
 
   zstr_cat(&help, "  ");
   tui_zstr_printf(&help, ANSI_BRIGHT_BLUE, "# fish (~/.config/fish/config.fish)");
   zstr_cat(&help, "\n");
-  zstr_cat(&help, "  eval (try init ~/src/tries | string collect)\n\n");
+  zstr_cat(&help, "  SHELL=/usr/bin/fish try init --base ~/src --install\n\n");
 
   // Commands section
   tui_zstr_printf(&help, TUI_H1, "Commands:");
@@ -83,6 +83,10 @@ static void print_help(void) {
   zstr_cat(&help, " (override with ");
   tui_zstr_printf(&help, TUI_BOLD, "--path");
   zstr_cat(&help, " on init)\n");
+
+  zstr_cat(&help, "  Multi-env: ");
+  tui_zstr_printf(&help, TUI_BOLD, "try init --base ~/src");
+  zstr_cat(&help, "\n");
 
   zstr_cat(&help, "  Current: ");
   tui_zstr_printf(&help, TUI_BOLD, zstr_cstr(&default_path));
@@ -134,6 +138,7 @@ static const char *parse_option_value(const char *arg, const char *next_arg,
 
 int main(int argc, char **argv) {
   Z_CLEANUP(zstr_free) zstr tries_path = zstr_init();
+  Z_CLEANUP(zstr_free) zstr base_path = zstr_init();
   Z_CLEANUP(vec_free_char_ptr) vec_char_ptr cmd_args = vec_init_capacity_char_ptr(argc);
 
   // Check NO_COLOR environment variable (https://no-color.org/)
@@ -177,6 +182,12 @@ int main(int argc, char **argv) {
       i += skip;
       continue;
     }
+    if ((value = parse_option_value(arg, next, "--base", &skip))) {
+      zstr_free(&base_path);
+      base_path = zstr_from(value);
+      i += skip;
+      continue;
+    }
     if ((value = parse_option_value(arg, next, "--and-keys", &skip))) {
       test.inject_keys = value;
       i += skip;
@@ -187,9 +198,30 @@ int main(int argc, char **argv) {
     vec_push_char_ptr(&cmd_args, argv[i]);
   }
 
-  // Default tries path
-  if (zstr_is_empty(&tries_path)) {
-    tries_path = get_default_tries_path();
+  // Determine paths
+  // --base means multi-env mode: base_path contains environments as subdirs
+  // --path or default means single-root mode
+  const char *base_path_cstr = NULL;  // NULL = single-root mode
+
+  if (!zstr_is_empty(&base_path)) {
+    base_path_cstr = zstr_cstr(&base_path);
+    // Ensure base directory exists
+    if (!dir_exists(base_path_cstr)) {
+      if (mkdir_p(base_path_cstr) != 0) {
+        fprintf(stderr, "Error: Could not create base directory: %s\n", base_path_cstr);
+        return 1;
+      }
+    }
+    // In multi-env mode, tries_path may be empty (clone/worktree use it)
+    // Default to the first subdir or leave empty
+    if (zstr_is_empty(&tries_path)) {
+      tries_path = get_default_tries_path();
+    }
+  } else {
+    // Single-root mode
+    if (zstr_is_empty(&tries_path)) {
+      tries_path = get_default_tries_path();
+    }
   }
 
   if (zstr_is_empty(&tries_path)) {
@@ -217,13 +249,13 @@ int main(int argc, char **argv) {
 
   // Route commands
   if (strcmp(command, "init") == 0) {
-    cmd_init((int)cmd_args.length - 1, cmd_args.data + 1, path_cstr);
+    cmd_init((int)cmd_args.length - 1, cmd_args.data + 1, path_cstr, base_path_cstr);
     return 0;
   } else if (strcmp(command, "exec") == 0) {
     // Exec mode - route subcommand and print script
     exec_mode = true;
     Z_CLEANUP(zstr_free) zstr script = cmd_route(
-        (int)cmd_args.length - 1, cmd_args.data + 1, path_cstr, &test);
+        (int)cmd_args.length - 1, cmd_args.data + 1, path_cstr, &test, base_path_cstr);
     if (zstr_is_empty(&script)) {
       return 1; // Error or special case (like init)
     }
@@ -231,7 +263,7 @@ int main(int argc, char **argv) {
   } else if (strcmp(command, "cd") == 0) {
     // Direct mode cd (interactive selector)
     Z_CLEANUP(zstr_free) zstr script = cmd_selector(
-        (int)cmd_args.length - 1, cmd_args.data + 1, path_cstr, &test);
+        (int)cmd_args.length - 1, cmd_args.data + 1, path_cstr, &test, base_path_cstr);
     if (zstr_is_empty(&script)) {
       return 1;
     }
@@ -239,7 +271,7 @@ int main(int argc, char **argv) {
   } else if (strcmp(command, "clone") == 0) {
     // Direct mode clone
     Z_CLEANUP(zstr_free) zstr script = cmd_clone(
-        (int)cmd_args.length - 1, cmd_args.data + 1, path_cstr);
+        (int)cmd_args.length - 1, cmd_args.data + 1, path_cstr, base_path_cstr);
     if (zstr_is_empty(&script)) {
       return 1;
     }
@@ -247,7 +279,7 @@ int main(int argc, char **argv) {
   } else if (strcmp(command, "worktree") == 0) {
     // Direct mode worktree
     Z_CLEANUP(zstr_free) zstr script = cmd_worktree(
-        (int)cmd_args.length - 1, cmd_args.data + 1, path_cstr);
+        (int)cmd_args.length - 1, cmd_args.data + 1, path_cstr, base_path_cstr);
     if (zstr_is_empty(&script)) {
       return 1;
     }
@@ -257,7 +289,7 @@ int main(int argc, char **argv) {
              strncmp(command, "git@", 4) == 0) {
     // URL shorthand for clone: try <url> = try clone <url>
     Z_CLEANUP(zstr_free) zstr script = cmd_clone(
-        (int)cmd_args.length, cmd_args.data, path_cstr);
+        (int)cmd_args.length, cmd_args.data, path_cstr, base_path_cstr);
     if (zstr_is_empty(&script)) {
       return 1;
     }

--- a/src/tui.c
+++ b/src/tui.c
@@ -35,6 +35,7 @@ static TuiInput filter_input = {0};
 static int selected_index = 0;
 static int scroll_offset = 0;
 static int marked_count = 0;  // Number of items marked for deletion
+static SelectorMode current_mode = SELECTOR_FOLDERS;
 
 // Memoized separator line
 static zstr cached_sep_line = {0};
@@ -496,7 +497,11 @@ static void render(const char *base_path) {
 
   // Header
   TuiStyleString line = tui_screen_line(&t);
-  tui_print(&line, TUI_H1, "🏠 Try Directory Selection");
+  if (current_mode == SELECTOR_ENVS) {
+    tui_print(&line, TUI_H1, "🌍 Select Environment");
+  } else {
+    tui_print(&line, TUI_H1, "🏠 Try Directory Selection");
+  }
   tui_screen_write_truncated(&t, &line, "… ");
 
   line = tui_screen_line(&t);
@@ -573,16 +578,24 @@ static void render(const char *base_path) {
       i++;
 
       // Generate preview name
-      time_t now = time(NULL);
-      struct tm *tm = localtime(&now);
-      char date_prefix[20];
-      strftime(date_prefix, sizeof(date_prefix), "%Y-%m-%d", tm);
-
-      Z_CLEANUP(zstr_free) zstr preview = zstr_from(date_prefix);
-      zstr_cat(&preview, "-");
-      const char *filter_text = zstr_cstr(&filter_input.text);
-      for (size_t j = 0; j < zstr_len(&filter_input.text); j++) {
-        zstr_push(&preview, isspace(filter_text[j]) ? '-' : filter_text[j]);
+      Z_CLEANUP(zstr_free) zstr preview = zstr_init();
+      if (current_mode == SELECTOR_ENVS) {
+        // Environments don't get date prefixes
+        const char *filter_text = zstr_cstr(&filter_input.text);
+        for (size_t j = 0; j < zstr_len(&filter_input.text); j++) {
+          zstr_push(&preview, isspace(filter_text[j]) ? '-' : filter_text[j]);
+        }
+      } else {
+        time_t now = time(NULL);
+        struct tm *tm = localtime(&now);
+        char date_prefix[20];
+        strftime(date_prefix, sizeof(date_prefix), "%Y-%m-%d", tm);
+        zstr_cat(&preview, date_prefix);
+        zstr_cat(&preview, "-");
+        const char *filter_text = zstr_cstr(&filter_input.text);
+        for (size_t j = 0; j < zstr_len(&filter_input.text); j++) {
+          zstr_push(&preview, isspace(filter_text[j]) ? '-' : filter_text[j]);
+        }
       }
 
       line = (idx == selected_index) ? tui_screen_line_selected(&t) : tui_screen_line(&t);
@@ -609,6 +622,8 @@ static void render(const char *base_path) {
     tui_print(&line, TUI_HIGHLIGHT, "DELETE MODE");
     tui_printf(&line, NULL, " | %d marked | ", marked_count);
     tui_print(&line, TUI_DARK, "Ctrl-D: Toggle  Enter: Confirm  Esc: Cancel");
+  } else if (current_mode == SELECTOR_ENVS) {
+    tui_print(&line, TUI_DARK, "↑/↓: Navigate  Enter: Select  Type to create new  Esc: Cancel");
   } else {
     tui_print(&line, TUI_DARK, "↑/↓: Navigate  Enter: Select  ^R: Rename  ^D: Delete  Esc: Cancel");
   }
@@ -618,7 +633,10 @@ static void render(const char *base_path) {
 
 SelectionResult run_selector(const char *base_path,
                              const char *initial_filter,
-                             TestParams *test) {
+                             TestParams *test,
+                             SelectorMode mode) {
+  current_mode = mode;
+
   // Initialize filter input
   if (zstr_len(&filter_input.text) == 0 && !filter_input.text.is_long) {
     filter_input = tui_input_init();
@@ -697,8 +715,8 @@ SelectionResult run_selector(const char *base_path,
         continue;
       }
       break;
-    } else if (c == 4) {
-      // Ctrl-D: Toggle mark on current item
+    } else if (c == 4 && current_mode == SELECTOR_FOLDERS) {
+      // Ctrl-D: Toggle mark on current item (folders only)
       if (selected_index < (int)filtered_ptrs.length) {
         TryEntry *entry = filtered_ptrs.data[selected_index];
         entry->marked_for_delete = !entry->marked_for_delete;
@@ -708,8 +726,8 @@ SelectionResult run_selector(const char *base_path,
           marked_count--;
         }
       }
-    } else if (c == 18) {
-      // Ctrl-R: Rename current item
+    } else if (c == 18 && current_mode == SELECTOR_FOLDERS) {
+      // Ctrl-R: Rename current item (folders only)
       if (selected_index < (int)filtered_ptrs.length) {
         TryEntry *entry = filtered_ptrs.data[selected_index];
         zstr new_name = render_rename_dialog(entry, test);
@@ -726,8 +744,8 @@ SelectionResult run_selector(const char *base_path,
         zstr_free(&new_name);
       }
     } else if (c == ENTER_KEY) {
-      // If items are marked, show confirmation dialog
-      if (marked_count > 0) {
+      // If items are marked (folders mode only), show confirmation dialog
+      if (marked_count > 0 && current_mode == SELECTOR_FOLDERS) {
         bool confirmed = render_delete_confirmation(base_path, test);
         if (confirmed) {
           // Collect all marked paths
@@ -755,18 +773,24 @@ SelectionResult run_selector(const char *base_path,
           break;
         }
 
-        time_t now = time(NULL);
-        struct tm *t = localtime(&now);
-        char date_prefix[20];
-        strftime(date_prefix, sizeof(date_prefix), "%Y-%m-%d", t);
+        if (current_mode == SELECTOR_ENVS) {
+          // Environments don't get date prefixes
+          result.type = ACTION_MKDIR;
+          result.path = join_path(base_path, zstr_cstr(&normalized));
+        } else {
+          time_t now = time(NULL);
+          struct tm *t = localtime(&now);
+          char date_prefix[20];
+          strftime(date_prefix, sizeof(date_prefix), "%Y-%m-%d", t);
 
-        zstr new_name = zstr_from(date_prefix);
-        zstr_cat(&new_name, "-");
-        zstr_cat(&new_name, zstr_cstr(&normalized));
+          zstr new_name = zstr_from(date_prefix);
+          zstr_cat(&new_name, "-");
+          zstr_cat(&new_name, zstr_cstr(&normalized));
 
-        result.type = ACTION_MKDIR;
-        result.path = join_path(base_path, zstr_cstr(&new_name));
-        zstr_free(&new_name);
+          result.type = ACTION_MKDIR;
+          result.path = join_path(base_path, zstr_cstr(&new_name));
+          zstr_free(&new_name);
+        }
       }
       break;
     } else if (c == ARROW_UP || c == 16) {  // UP or Ctrl-P

--- a/src/tui.h
+++ b/src/tui.h
@@ -13,6 +13,11 @@ Z_VEC_GENERATE_IMPL(zstr, zstr)
 // ============================================================================
 
 typedef enum {
+  SELECTOR_FOLDERS,  // Normal mode: pick/create folders in tries_path
+  SELECTOR_ENVS      // Env mode: pick environment subdirectory from base_path
+} SelectorMode;
+
+typedef enum {
   ACTION_NONE,
   ACTION_CD,
   ACTION_MKDIR,
@@ -46,7 +51,8 @@ typedef struct {
 } TestParams;
 
 // Selector
+// mode: SELECTOR_FOLDERS for normal folder picker, SELECTOR_ENVS for environment picker
 SelectionResult run_selector(const char *base_path, const char *initial_filter,
-                             TestParams *test);
+                             TestParams *test, SelectorMode mode);
 
 #endif /* TUI_H */


### PR DESCRIPTION
Add two major features to try:

1. Multi-environment mode (--base)
   - `try init --base ~/src` organizes workspaces into multiple
     environments (tries, experiments, prod) under a base directory
   - Two-step TUI: first pick an environment, then pick/create a project
   - Each subdirectory of the base path becomes an environment
   - New environments can be created on-the-fly by typing a name
   - ENV mode disables delete/rename (only projects get those)
   - Fully backward compatible: single-root mode unchanged

2. One-command setup (--install)
   - `try init --base ~/src --install` does everything:
     - Creates the base directory and default env subdirs
     - Auto-detects shell (zsh/bash/fish) from $SHELL
     - Appends shell function to the right config file
     - Skips if a try function is already present
   - All output goes to stderr (nothing on stdout) to prevent
     accidental eval side effects