### PR TITLE
fix: set portable interpreter path for Linux release binaries

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -96,6 +96,7 @@
             nativeBuildInputs = with pkgs; [
               gcc
               gnumake
+              patchelf
             ];
 
             buildPhase = ''
@@ -105,6 +106,8 @@
             installPhase = ''
               mkdir -p $out/bin
               cp dist/try $out/bin/
+              # Set portable interpreter path for non-Nix systems
+              patchelf --set-interpreter /lib64/ld-linux-x86-64.so.2 $out/bin/try
             '';
 
             meta = with pkgs.lib; {
@@ -125,6 +128,7 @@
             nativeBuildInputs = with pkgs.pkgsCross.aarch64-multiplatform; [
               gcc
               gnumake
+              patchelf
             ];
 
             buildPhase = ''
@@ -134,6 +138,8 @@
             installPhase = ''
               mkdir -p $out/bin
               cp dist/try $out/bin/
+              # Set portable interpreter path for non-Nix systems
+              patchelf --set-interpreter /lib/ld-linux-aarch64.so.1 $out/bin/try
             '';
 
             meta = with pkgs.lib; {


### PR DESCRIPTION
This change uses `patchelf` to set the interpreter as `ld-linux-x86-64.so.2` (or `ld-linux-aarch64.so.1` on aarch64) instead of the default, which references Nix and isn't available on other distros.

See #15 for reference. The built `try` from the releases page shows:

```bash
$ file try
try: ELF 64-bit LSB shared object, x86-64, version 1 (SYSV), dynamically linked, interpreter /nix/store/xx7cm72qy2c0643cm1ipngd87aqwkcdp-glibc-2.40-66/lib/ld-linux-
x86-64.so.2
```

Which causes this error when running:

```bash
$ ./try
bash: ./try: No such file or directory
```

This change adds patchelf as a step after building to explicitly point at the actual paths for ld-linux.

Honestly, I'm not familiar enough with Nix at this point to know if this is the best way of doing it. I used an agent to help me implement this.

I'm leaning towards #17 as a better fix for this behavior, as I feel this is more of a temp workaround.